### PR TITLE
feat(DEX-3929): Add exports for testing utils

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 The purpose of this file is to document any changes done over upstream (https://github.com/openedx/frontend-app-learning).
 
+## 2023-09-06
+
+- Added `src/testExports.js` to export anything that needs to be reused for testing but we don't want to be on production builds.
+- Added "exports" entry to package.json to expose test exports.
+- Exported testing utils.
+
 ## 2023-08-28
 
 - Exported components required for using Sequence.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0-semantically-released",
   "description": "Frontend learning application.",
   "main": "dist/exports.js",
+  "exports": {
+    ".": "./dist/exports.js",
+    "./tests": "./dist/testExports.js"
+  },
   "files": [
     "/dist"
   ],

--- a/src/exports.js
+++ b/src/exports.js
@@ -1,11 +1,7 @@
 import Sequence from './courseware/course/sequence';
-import CompleteIcon from './courseware/course/sequence/sequence-navigation/CompleteIcon';
 import { reducer as courseHomeReducer } from './course-home/data';
 import { reducer as coursewareReducer } from './courseware/data/slice';
-import { reducer as recommendationsReducer } from './courseware/course/course-exit/data/slice';
-import { reducer as toursReducer } from './product-tours/data';
 import { reducer as modelsReducer } from './generic/model-store';
-import CourseLicense from './courseware/course/course-license';
 import {
   fetchCourse,
   fetchSequence,
@@ -14,20 +10,19 @@ import {
   getResumeBlock,
   getSequenceForUnitDeprecated,
 } from './courseware/data';
+import { executeThunk, appendBrowserTimezoneToUrl } from './utils';
 
 export {
   Sequence,
-  CompleteIcon,
   courseHomeReducer,
   coursewareReducer,
-  recommendationsReducer,
-  toursReducer,
   modelsReducer,
-  CourseLicense,
   fetchCourse,
   fetchSequence,
   checkBlockCompletion,
   saveSequencePosition,
   getResumeBlock,
   getSequenceForUnitDeprecated,
+  executeThunk,
+  appendBrowserTimezoneToUrl,
 };

--- a/src/testExports.js
+++ b/src/testExports.js
@@ -1,0 +1,21 @@
+/*
+  Test Exports:
+  This module exports anything that needs to be reused for testing
+  but we don't want to be on production builds.
+
+  This is required because some test modules execute code by just
+  importing them that creates global objects (like mock factories)
+  that we don't want to include on production.
+*/
+
+import * as courseMetadataFactory from './courseware/data/__factories__/courseMetadata.factory';
+import * as sequenceMetadataFactory from './courseware/data/__factories__/sequenceMetadata.factory';
+import * as learningSequencesOutlineFactory from './courseware/data/__factories__/learningSequencesOutline.factory';
+import * as courseHomeFactories from './course-home/data/__factories__';
+
+export {
+  courseMetadataFactory,
+  sequenceMetadataFactory,
+  learningSequencesOutlineFactory,
+  courseHomeFactories,
+};


### PR DESCRIPTION
# Overview

- Added `src/testExports.js` to export anything that needs to be reused for testing but we don't want to be on production builds.
- Added "exports" entry to package.json to expose test exports.
- Exported testing utils.
- Cleaned up unused exports.

About exporting test utils separately:

This is required because some test modules execute code by just importing them that creates global objects (like mock factories) that we don't want to include on production.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] All changes are documented on `CHANGES.md`
- [x] Code is correctly formatted and linted
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check work before asking for reviewers
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
